### PR TITLE
Use the power of http_build_query instead of building a query string by hand

### DIFF
--- a/src/DocRaptor.php
+++ b/src/DocRaptor.php
@@ -103,9 +103,7 @@ class ApiWrapper {
         $fields['doc[document_url]'] = urlencode($this->document_url);
       }
 
-      $fields_string = '';
-      foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
-      rtrim($fields_string,'&');
+      $fields_string = http_build_query($fields);
       $ch = curl_init();
       curl_setopt($ch,CURLOPT_URL,$url);
       curl_setopt($ch,CURLOPT_POST,count($fields));


### PR DESCRIPTION
Looks like this PR got merged incorrectly: https://github.com/krewenki/php-docraptor/pull/7/files
