### PR TITLE
Async and CallbackURL Added to API Wrapper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -87,6 +87,15 @@ $docRaptor->setSecure(false);
 
 NB! It IS not secure, you're basically broadcasting your api key over the network.
 
+###Async
+By default, PHP-DocRaptor submits requests by synchronous.  However, if you are trying to process large files you will need to make an asynchronous request.  You can choose to do this by passing an argument to the *setAsync()* method (true for asynchronous, false for synchronous request):
+
+```php
+$docRaptor->setAsync(true);
+```
+
+Synchronous requests will return the file contents where as asynchronous requests will return a json response.  Examples of the response can be found in the [API documentation](https://docraptor.com/documentation#api_async)
+
 ## Contributing
 
 If you find a bug, please make a [new GitHub issue](https://github.com/expectedbehavior/php-docraptor/issues/new). If you know how to solve it, make a branch and once you're done make a [new pull request](https://github.com/expectedbehavior/php-docraptor/compare).

--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,15 @@ $docRaptor->setAsync(true);
 
 Synchronous requests will return the file contents where as asynchronous requests will return a json response.  Examples of the response can be found in the [API documentation](https://docraptor.com/documentation#api_async)
 
+###Async Callback URL
+If *setAsync()* is true and you want DocRaptor to do a POST request to your system when an asynchronous job has generated you can set the callback url via *setCallbackUrl()*:
+
+```php
+$docRaptor->setCallbackUrl('http://your-url.com');
+```
+
+Details on the POST request can be found in the [API documentation](https://docraptor.com/documentation#api_callback_url)
+
 ## Contributing
 
 If you find a bug, please make a [new GitHub issue](https://github.com/expectedbehavior/php-docraptor/issues/new). If you know how to solve it, make a branch and once you're done make a [new pull request](https://github.com/expectedbehavior/php-docraptor/compare).

--- a/src/ApiWrapper.php
+++ b/src/ApiWrapper.php
@@ -24,6 +24,7 @@ class ApiWrapper
     protected $api_key;
     protected $url_protocol             = 'https';
     protected $api_url                  = 'docraptor.com/docs';
+    protected $async                     = false;
 
     // Output document related
     protected $document_type            = 'pdf';
@@ -81,6 +82,16 @@ class ApiWrapper
     public function getApiKey()
     {
         return $this->api_key;
+    }
+    
+    /**
+     * @param boolean $async
+     * @return $this
+     */
+    public function setJavascript($async)
+    {
+        $this->async = $async;
+        return $this;
     }
 
     /**
@@ -270,6 +281,7 @@ class ApiWrapper
             'doc[test]'          => $this->test,
             'doc[strict]'        => $this->strict,
             'doc[javascript]'    => $this->javascript,
+            'doc[async]'         => $this->async,
         );
 
         if (!empty($this->baseurl)) {

--- a/src/ApiWrapper.php
+++ b/src/ApiWrapper.php
@@ -295,7 +295,7 @@ class ApiWrapper
             'doc[async]'         => $this->async,
         );
         
-        if (!empty($this->callback_url)) {
+        if (!empty($this->callback_url) && $this->async == true) {
             $fields['doc[callback_url]'] = $this->callback_url;
         }
         

--- a/src/ApiWrapper.php
+++ b/src/ApiWrapper.php
@@ -25,6 +25,7 @@ class ApiWrapper
     protected $url_protocol             = 'https';
     protected $api_url                  = 'docraptor.com/docs';
     protected $async                    = false;
+    protected $callback_url;
 
     // Output document related
     protected $document_type            = 'pdf';
@@ -91,6 +92,16 @@ class ApiWrapper
     public function setAsync($async)
     {
         $this->async = $async;
+        return $this;
+    }
+    
+    /**
+     * @param string|null $callback_url
+     * @return $this
+     */
+    public function setCallbackUrl($callback_url)
+    {
+        $this->callback_url = $callback_url;
         return $this;
     }
 
@@ -283,7 +294,11 @@ class ApiWrapper
             'doc[javascript]'    => $this->javascript,
             'doc[async]'         => $this->async,
         );
-
+        
+        if (!empty($this->callback_url)) {
+            $fields['doc[callback_url]'] = $this->callback_url;
+        }
+        
         if (!empty($this->baseurl)) {
             $fields['doc[prince_options][baseurl]'] = $this->baseurl;
         }

--- a/src/ApiWrapper.php
+++ b/src/ApiWrapper.php
@@ -24,7 +24,7 @@ class ApiWrapper
     protected $api_key;
     protected $url_protocol             = 'https';
     protected $api_url                  = 'docraptor.com/docs';
-    protected $async                     = false;
+    protected $async                    = false;
 
     // Output document related
     protected $document_type            = 'pdf';

--- a/src/ApiWrapper.php
+++ b/src/ApiWrapper.php
@@ -88,7 +88,7 @@ class ApiWrapper
      * @param boolean $async
      * @return $this
      */
-    public function setJavascript($async)
+    public function setAsync($async)
     {
         $this->async = $async;
         return $this;


### PR DESCRIPTION
Ability to call setAsync() and also setCallbackUrl() for async requests.

I have left file_put_contents ability for async true as it is users decision to save to file or alternatively read the response. 
